### PR TITLE
fix: rootページ追加に伴い、routes.rbを修正

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,15 +1,3 @@
 Rails.application.routes.draw do
-  get "static_pages/top"
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
-  get "up" => "rails/health#show", as: :rails_health_check
-
-  # Render dynamic PWA files from app/views/pwa/*
-  get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
-  get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
-
-  # Defines the root path route ("/")
-  # root "posts#index"
+  root "static_pages#top"
 end


### PR DESCRIPTION
## 概要
rootページを追加しました。
`root "static_pages#top"`

それに伴い、routes.rbの不要なコメントやルートを削除しました。